### PR TITLE
Fixed missing time stamp

### DIFF
--- a/src/merger/constants.rs
+++ b/src/merger/constants.rs
@@ -11,6 +11,7 @@ pub const SIZE_OF_BITSET: usize = 72;
 
 // Electronics constants
 pub const NUMBER_OF_COBOS: u8 = 11; //total
+pub const COBO_WITH_TIMESTAMP: u8 = 10; // cobo with TS in sync with FRIBDAQ
 pub const NUMBER_OF_ASADS: u8 = 4; //per cobo
 pub const NUMBER_OF_AGETS: u8 = 4; // per asad
 pub const NUMBER_OF_CHANNELS: u8 = 68;


### PR DESCRIPTION
Added other time stamp in GET header, extracted from the CoBo that gets it from the other DAQ.